### PR TITLE
fix: reset password URL

### DIFF
--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -123,7 +123,7 @@ export const forgotPassword = async (req, res) => {
     });
 
     // Create the reset password URL, which includes the reset password token.
-    const resetUrl = `${envConfig.clientHost}/reset-password?token=${resetToken}`;
+    const resetUrl = `${envConfig.clientHost}/reset-password/${resetToken}`;
 
     // Send an email to the user that includes the reset password URL
     await transporter.sendMail({


### PR DESCRIPTION
I found a bug in the email link that users click on to be redirected to the reset password page while working on the front-end app. 